### PR TITLE
fix: 結果画面のcssを修正

### DIFF
--- a/src/views/Result.vue
+++ b/src/views/Result.vue
@@ -122,9 +122,6 @@ export default {
 	text-decoration: none;
 	margin-right: 30px;
 }
-.card {
-	height: 500px;
-}
 .fadeIn {
   opacity: 0;
   animation: fadeIn 1s ease forwards;


### PR DESCRIPTION
### 問題点
* クイズ結果の文言が長くなった場合にレイアウトが崩れてボタンが枠の外に表示されてしまう。

### 解決方法
* 結果画面のv-cardコンポーネントの高さの制約をなくした。